### PR TITLE
feat: add hook, rust-test

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,3 +20,10 @@
   args: ["--", "-D", "warnings"]
   types: [rust]
   pass_filenames: false
+- id: rust-test
+  name: rust test
+  description: Run tests
+  entry: cargo test
+  language: system
+  types: [rust]
+  pass_filenames: false


### PR DESCRIPTION
Add new hook to support users that practice TDD or want to ensure tests are run prior to commits/pushes.